### PR TITLE
Increased compatibility with area protection.

### DIFF
--- a/computer_env.lua
+++ b/computer_env.lua
@@ -2866,12 +2866,8 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 		if not pos then
 			return false
 		end
-
-		local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-		local in_protected_area = minetest.is_protected (pos, "")
-		local denied = not in_owned_area and in_protected_area
 		
-		if denied then
+		if minetest.is_protected (pos, meta:get_string("owner")) then
 			return false
 		end
 
@@ -3026,11 +3022,8 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 
 		local nodedef = minetest.registered_nodes[node.name]
 
-		local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-		local in_protected_area = minetest.is_protected (pos, "")
-		local denied = not in_owned_area and in_protected_area
-
-		if not nodedef or not nodedef.diggable or denied or
+		if not nodedef or not nodedef.diggable or 
+      minetest.is_protected (pos, meta:get_string("owner")) or
 			minetest.get_item_group (node.name, "unbreakable") > 0 then
 			return nil
 		end
@@ -3146,11 +3139,7 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 			end
 		end
 
-		local in_owned_area = not minetest.is_protected (place_pos, meta:get_string("owner"))
-		local in_protected_area = minetest.is_protected (place_pos, "")
-		local denied = not in_owned_area and in_protected_area
-
-		if denied then
+		if minetest.is_protected (place_pos, meta:get_string("owner")) then
 			return false
 		end
 
@@ -3177,7 +3166,7 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 			pointed_thing.above = place_pos
 		end
 
-		if lwcomp.settings.use_mod_on_place and not in_protected_area then
+		if lwcomp.settings.use_mod_on_place and not minetest.is_protected (place_pos, "") then
 			if def and def.on_place then
 				local result, leftover = pcall (def.on_place, stack, nil, pointed_thing)
 
@@ -3333,12 +3322,8 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 		if not pos then
 			return false
 		end
-
-		local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-		local in_protected_area = minetest.is_protected (pos, "")
-		local denied = not in_owned_area and in_protected_area
 		
-		if denied then
+		if minetest.is_protected (pos, meta:get_string("owner")) then
 			return false
 		end
 
@@ -3436,12 +3421,8 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 		if not pos then
 			return false
 		end
-
-		local in_owned_area = not minetest.is_protected(pos, meta:get_string("owner"))
-		local in_protected_area = minetest.is_protected (pos, "")
-		local denied = not in_owned_area and in_protected_area
 		
-		if denied then
+		if minetest.is_protected (pos, meta:get_string("owner")) then
 			return false
 		end
 

--- a/computer_env.lua
+++ b/computer_env.lua
@@ -2908,7 +2908,7 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 			inv_storage[i] = inv:get_stack ("storage", i)
 		end
 
-    local owner = meta:get_string ("owner")
+		local owner = meta:get_string ("owner")
 		local id = meta:get_int ("lwcomputer_id")
 		local running = meta:get_int ("running")
 		local persists = meta:get_int ("persists")
@@ -2945,7 +2945,7 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 		inv:set_size ("storage", 32)
 		inv:set_width ("storage", 8)
 
-    meta:set_string ("owner", owner)
+		meta:set_string ("owner", owner)
 		meta:set_int ("lwcomputer_id", id)
 		meta:set_int ("running", running)
 		meta:set_int ("robot", 1)
@@ -3023,7 +3023,7 @@ function lwcomp.new_computer (computer_pos, computer_id, computer_persists, robo
 		local nodedef = minetest.registered_nodes[node.name]
 
 		if not nodedef or not nodedef.diggable or 
-      minetest.is_protected (pos, meta:get_string("owner")) or
+			minetest.is_protected (pos, meta:get_string("owner")) or
 			minetest.get_item_group (node.name, "unbreakable") > 0 then
 			return nil
 		end


### PR DESCRIPTION
Robots can no longer move into protected areas or interact with chests in protected areas unless the owner of the robot is the owner of the protected area.

Robots can now place and dig nodes inside a protected area if the owner of the robot is also the owner of the protected area.
